### PR TITLE
feat: add associations + user requests ep + tests

### DIFF
--- a/API/migrations/20230915175200-create-request.js
+++ b/API/migrations/20230915175200-create-request.js
@@ -9,6 +9,14 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.UUID
       },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: {
+          model: 'users',
+          key: 'id'
+        },
+      },
       group_id: {
         type: Sequelize.STRING,
         allowNull: false

--- a/API/models/request.js
+++ b/API/models/request.js
@@ -11,6 +11,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
+      request.belongsTo(models.user, { foreignKey: 'user_id'});
     }
   }
   request.init(
@@ -21,6 +22,18 @@ module.exports = (sequelize, DataTypes) => {
         defaultValue: DataTypes.UUIDV4,
         primaryKey: true
     },
+    user_id: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        validate: {
+          notEmpty: {
+            msg: "User ID cannot be empty"
+          },
+          notNull: {
+            msg: "User ID cannot be null"
+          }
+        }
+      },
       group_id: {
         type: DataTypes.STRING,
         allowNull: false,

--- a/API/models/user.js
+++ b/API/models/user.js
@@ -11,6 +11,7 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
+      User.hasMany(models.request, { foreignKey: 'user_id'});
     }
   }
   User.init({

--- a/API/seeders/20230813092025-demo-data-users.js
+++ b/API/seeders/20230813092025-demo-data-users.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { v4: uuidv4 } = require('uuid');
-
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.bulkInsert('users', [
@@ -18,7 +16,7 @@ module.exports = {
         updatedAt: new Date()
       },
       {
-        id: uuidv4(),
+        id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f1",
         username: 'JaneDoe',
         password: 'Jane@1234',
         email: 'jane.doe@example.com',
@@ -30,7 +28,7 @@ module.exports = {
         updatedAt: new Date()
       },
       {
-        id: uuidv4(),
+        id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f2",
         username: 'BillyBob',
         password: 'Billy@1234',
         email: 'billy.bob@example.com',
@@ -42,7 +40,7 @@ module.exports = {
         updatedAt: new Date()
       },
       {
-        id: uuidv4(),
+        id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f3",
         username: 'EmilyRose',
         password: 'Rose@1234',
         email: 'emily.rose@example.com',
@@ -54,7 +52,7 @@ module.exports = {
         updatedAt: new Date()
       },
       {
-        id: uuidv4(),
+        id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f4",
         username: 'CharlieBrown',
         password: 'Brown@1234',
         email: 'charlie.brown@example.com',

--- a/API/seeders/20230910013800-demo-data-requests.js
+++ b/API/seeders/20230910013800-demo-data-requests.js
@@ -6,6 +6,7 @@ module.exports = {
   async up (queryInterface, Sequelize) {
     await queryInterface.bulkInsert('requests', [
       { id: uuidv4(),
+        user_id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f0",
         group_id: '13',
         symbol: "AAPL",
         datetime: new Date(),
@@ -16,6 +17,7 @@ module.exports = {
         updatedAt: new Date() },
       
       {  id: uuidv4(),
+        user_id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f1",
         group_id: '2',
         symbol: "AMZN",
         datetime: new Date(),
@@ -26,6 +28,7 @@ module.exports = {
         updatedAt: new Date() },
       
       {  id: uuidv4(),
+        user_id: "8a04cb0b-9c2a-4895-8e5c-95626ad9d1f2",
         group_id: '1',
         symbol: "GOOGL",
         datetime: new Date(),

--- a/API/src/controllers/request.controller.js
+++ b/API/src/controllers/request.controller.js
@@ -126,11 +126,12 @@ const postRequests = async (req, res) => {
     }
 
     const {
-      group_id, symbol, datetime, deposit_token, quantity, seller,
+      user_id, group_id, symbol, datetime, deposit_token, quantity, seller,
     } = request;
 
     if (
-      !group_id
+      !user_id
+      || !group_id
       || !symbol
       || !datetime
       || deposit_token === undefined
@@ -141,6 +142,7 @@ const postRequests = async (req, res) => {
     }
 
     const newRequest = await Request.create({
+      user_id,
       group_id,
       symbol,
       datetime,
@@ -149,7 +151,9 @@ const postRequests = async (req, res) => {
       seller,
     });
 
-    res.status(201).json({ message: `Request ${newRequest.id} @ ${datetime} created successfully` });
+    // const url = `${process.env.API_PROTOCOL}://${process.env.API_HOST}:${process.env.API_PORT}${apiPath}`;
+
+    res.status(201).json({ message: `Request ${newRequest.id} from user ${user_id}: @ ${datetime} created successfully` });
   } catch (error) {
     res.status(500).json({ message: 'Internal Server Error', error: error.message });
   }

--- a/API/src/routes/user.routes.js
+++ b/API/src/routes/user.routes.js
@@ -3,8 +3,9 @@ const express = require('express');
 const {
   getUsers,
   getUser,
+  getUserRequests,
   postUser,
-  postIncreaseWallet,
+  postUpdateWallet,
 } = require('../controllers/user.controller');
 
 const userRoutes = express.Router();
@@ -13,8 +14,11 @@ userRoutes.route('/')
   .get(getUsers)
   .post(postUser);
 
+userRoutes.route('/requests/:id/')
+  .get(getUserRequests);
+
 userRoutes.route('/wallet/:id')
-  .post(postIncreaseWallet);
+  .post(postUpdateWallet);
 
 userRoutes.route('/:id')
   .get(getUser);

--- a/API/src/tests/userRoutes.test.js
+++ b/API/src/tests/userRoutes.test.js
@@ -4,6 +4,7 @@ const db = require('../../models');
 const {
   mockUserId,
   correctMockUser,
+  mockUserMoney,
   incorrectMockUser,
 } = require('./utils/userRoutes.util');
 
@@ -17,6 +18,18 @@ describe('Users API - General Cases', () => {
 
   it('should return a user', async () => {
     const res = await request(app).get(`/users/${mockUserId}`);
+    expect(res.statusCode).toEqual(200);
+  });
+
+  it('should return all user\'s requests', async () => {
+    const res = await request(app).get(`/users/requests/${mockUserId}`);
+    expect(res.statusCode).toEqual(200);
+  });
+
+  it('should add money to a user', async () => {
+    const res = await request(app).post(`/users/wallet/${mockUserId}`).send({
+      amount: mockUserMoney,
+    });
     expect(res.statusCode).toEqual(200);
   });
 
@@ -48,5 +61,17 @@ describe('Users API - Error Cases', () => {
   it('should return 500 trying to post a user', async () => {
     const res = await request(app).post('/users').send(incorrectMockUser);
     expect(res.statusCode).toEqual(500);
+  });
+
+  it('should return 500 trying to get a user\'s requests', async () => {
+    const res = await request(app).post('/users').send();
+    expect(res.statusCode).toEqual(500);
+  });
+
+  it('should return 500 trying to add money to a user', async () => {
+    const res = await request(app).post(`/users/wallet/${mockUserId}`).send({
+      cash: mockUserMoney,
+    });
+    expect(res.statusCode).toEqual(400);
   });
 });

--- a/API/src/tests/utils/requestRoutes.util.js
+++ b/API/src/tests/utils/requestRoutes.util.js
@@ -1,4 +1,5 @@
 const correctMockRequest = {
+  user_id: '8a04cb0b-9c2a-4895-8e5c-95626ad9d1f0',
   group_id: 'group69',
   symbol: 'AAPL',
   datetime: '2023-09-15T12:34:56Z',

--- a/API/src/tests/utils/userRoutes.util.js
+++ b/API/src/tests/utils/userRoutes.util.js
@@ -25,8 +25,11 @@ const correctMockUser = {
 };
 const incorrectMockUser = {};
 
+const mockUserMoney = 1000.69;
+
 module.exports = {
   mockUserId,
+  mockUserMoney,
   correctMockUser,
   incorrectMockUser,
 };


### PR DESCRIPTION
# Description

Agregue una asociacion entre `User` y `Request` (1:n). Con esto, `sequelize` nos crea un metodo automaticamente llamado `getUserRequests` y nos retorna todos los `Request` que hagan un match con el `id` del `User`. Para usar esto, hice un endpoint que retorna lo que mencione, en la ruta `/users/requests/:id`. Es muy importante tener en cuenta que ahora **NO** se puede crear una `request` sin tener un `user_id` asociado. Ahora es literalmente una nueva columna en esa tabla.

Tambien agregue nuevos `tests` para asegurarme de que esto funcionase bien.

Finalmente, updatie un poquito la funcion de agregar dinero para que no pudiese gastar mas de lo que tuviese (como yo).


## Tipo de cambio

<!-- Por favor eliminen las opciones que no aplican. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# ¿Cómo revisé mi código?

Testeo de integracion y `postman`.

# Checklist:

- [X] Mi código sigue las guías de estilo del proyecto
- [X] Realicé la revisión de mi código
- [X] Hice los cambios respectivos de la documentación en caso de ser necesario
- [X] Mis cambios no generan errores nuevos
- [X] Revisé que las funcionalidades funcionan como se espera
