### PR TITLE
🐋 fix(docker-compose.yaml): Update security settings of favonia/cloudflare-ddns

### DIFF
--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -86,21 +86,14 @@ services:
     network_mode: host
     # Restart the updater after reboot
     restart: always
-    cap_add:
-      # Capability to change user ID; needed for using PUID
-      - SETUID
-      # Capability to change group ID; needed for using PGID
-      - SETGID
+    # Run the updater with user/group ID 1000
+    user: "1000:1000"
     # Make the container filesystem read-only
     read_only: true
     security_opt:
       # Another protection to restrict superuser privileges
       - no-new-privileges:true
     environment:
-      # Run the updater with user ID 1000
-      - PUID=1000
-      # Run the updater with group ID 1000
-      - PGID=1000
       # Your Cloudflare API token
       - CF_API_TOKEN=${CLOUDFLARE_API_KEY}
       # Your domains (separated by commas)

--- a/docker-compose.production.yaml
+++ b/docker-compose.production.yaml
@@ -82,21 +82,14 @@ services:
     network_mode: host
     # Restart the updater after reboot
     restart: always
-    cap_add:
-      # Capability to change user ID; needed for using PUID
-      - SETUID
-      # Capability to change group ID; needed for using PGID
-      - SETGID
+    # Run the updater with user/group ID 1000
+    user: "1000:1000"
     # Make the container filesystem read-only
     read_only: true
     security_opt:
       # Another protection to restrict superuser privileges
       - no-new-privileges:true
     environment:
-      # Run the updater with user ID 1000
-      - PUID=1000
-      # Run the updater with group ID 1000
-      - PGID=1000
       # Your Cloudflare API token
       - CF_API_TOKEN=${CLOUDFLARE_API_KEY}
       # Your domains (separated by commas)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,21 +82,14 @@ services:
     network_mode: host
     # Restart the updater after reboot
     restart: always
-    cap_add:
-      # Capability to change user ID; needed for using PUID
-      - SETUID
-      # Capability to change group ID; needed for using PGID
-      - SETGID
+    # Run the updater with user/group ID 1000
+    user: "1000:1000"
     # Make the container filesystem read-only
     read_only: true
     security_opt:
       # Another protection to restrict superuser privileges
       - no-new-privileges:true
     environment:
-      # Run the updater with user ID 1000
-      - PUID=1000
-      # Run the updater with group ID 1000
-      - PGID=1000
       # Your Cloudflare API token
       - CF_API_TOKEN=${CLOUDFLARE_API_KEY}
       # Your domains (separated by commas)

--- a/workers/docker-compose.yaml
+++ b/workers/docker-compose.yaml
@@ -108,21 +108,14 @@ services:
     network_mode: host
     # Restart the updater after reboot
     restart: always
-    cap_add:
-      # Capability to change user ID; needed for using PUID
-      - SETUID
-      # Capability to change group ID; needed for using PGID
-      - SETGID
+    # Run the updater with user/group ID 1000
+    user: "1000:1000"
     # Make the container filesystem read-only
     read_only: true
     security_opt:
       # Another protection to restrict superuser privileges
       - no-new-privileges:true
     environment:
-      # Run the updater with user ID 1000
-      - PUID=1000
-      # Run the updater with group ID 1000
-      - PGID=1000
       # Your Cloudflare API token
       - CF_API_TOKEN=${CLOUDFLARE_API_KEY}
       # Your domains (separated by commas)


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.